### PR TITLE
refactor(pyproject.toml): change project.optional-dependencies to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,16 +32,23 @@ dependencies = [
     "taskiq>=0.12.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
+    {include-group = "lint"},
+    {include-group = "test"},
+    "pre-commit>=4.5.0",
+]
+test = [
+    "pytest>=9.0.1",
+    "pytest-cov>=7.0.0",
+]
+lint = [
     "black>=25.11.0",
     "coverage>=7.12.0",
     "mypy>=1.19.0",
-    "pre-commit>=4.5.0",
-    "pytest>=9.0.1",
-    "pytest-cov>=7.0.0",
     "ruff>=0.14.7",
 ]
+
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Add same fix according to this [comment](https://github.com/taskiq-python/taskiq-psqlpy/pull/11#discussion_r2594716754) 